### PR TITLE
Build a way to chain contexts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-context"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-context"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-context"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Peter Farr <Peter@PrismaPhonic.com>"]
 description = "Contexts for cancelling asynchronous tasks using tokio"
 keywords = ["async", "api", "tokio", "futures"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Released API docs](https://docs.rs/tokio-context/badge.svg)](https://docs.rs/tokio-context)
 
-## tokio-context
+# tokio-context
 
 Provides two different methods for cancelling futures with a provided handle for cancelling all
 related futures, with a fallback timeout mechanism. This is accomplished either with the
@@ -14,15 +14,15 @@ Provides Golang like Context functionality. A Context in this respect is an obje
 passed around, primarily to async functions, that is used to determine if long running
 asynchronous tasks should continue to run, or terminate.
 
-You build a new Context by calling its `Context::new` constructor, which optionally takes a
-duration that the context should run for. Calling the `Context::new` constructor returns the
-new `Context` along with a `Handle`. The `Handle` can either have its `cancel` method
-called, or it can simply be dropped to cancel the context.
+You build a new Context by calling its `new` constructor, which returns the new
+`Context` along with a `Handle`. The `Handle` can either have its `cancel`
+method called, or it can simply be dropped to cancel the context.
 
 Please note that dropping the `Handle` **will** cancel the context.
 
-If the duration supplied during `Context` construction elapses, then the `Context` will
-also be cancelled.
+If you would like to create a Context that automatically cancels after a given duration has
+passed, use the `with_timeout` constructor. Using this constructor will still
+give you a handle that can be used to immediately cancel the context as well.
 
 ## Examples
 
@@ -40,7 +40,7 @@ async fn task_that_takes_too_long() {
 async fn main() {
     // We've decided that we want a long running asynchronous task to last for a maximum of 1
     // second.
-    let (mut ctx, _handle) = Context::new(Some(Duration::from_secs(1)));
+    let (mut ctx, _handle) = Context::with_timeout(Duration::from_secs(1));
 
     tokio::select! {
         _ = ctx.done() => return,
@@ -70,7 +70,7 @@ async fn task_that_takes_too_long(mut ctx: Context) {
 
 #[tokio::main]
 async fn main() {
-    let (_, mut handle) = Context::new(None);
+    let (_, mut handle) = Context::new();
 
     let mut join_handles = vec![];
 
@@ -105,7 +105,7 @@ use tokio_context::context::RefContext;
 #[tokio::test]
 async fn cancelling_parent_ctx_cancels_child() {
     // Note that we can't simply drop the handle here or the context will be cancelled.
-    let (parent_ctx, parent_handle) = RefContext::new(None);
+    let (parent_ctx, parent_handle) = RefContext::new();
     let (mut ctx, _handle) = Context::with_parent(&parent_ctx, None);
 
     parent_handle.cancel();
@@ -120,7 +120,7 @@ async fn cancelling_parent_ctx_cancels_child() {
 #[tokio::test]
 async fn cancelling_child_ctx_doesnt_cancel_parent() {
     // Note that we can't simply drop the handle here or the context will be cancelled.
-    let (mut parent_ctx, _parent_handle) = RefContext::new(None);
+    let (mut parent_ctx, _parent_handle) = RefContext::new();
     let (_ctx, handle) = Context::with_parent(&parent_ctx, None);
 
     handle.cancel();
@@ -135,7 +135,7 @@ async fn cancelling_child_ctx_doesnt_cancel_parent() {
 #[tokio::test]
 async fn parent_timeout_cancels_child() {
     // Note that we can't simply drop the handle here or the context will be cancelled.
-    let (parent_ctx, _parent_handle) = RefContext::new(Some(Duration::from_millis(5)));
+    let (parent_ctx, _parent_handle) = RefContext::with_timeout(Duration::from_millis(5));
     let (mut ctx, _handle) =
         Context::with_parent(&parent_ctx, Some(Duration::from_millis(10)));
 
@@ -156,16 +156,17 @@ termination, which may not always be desired.
 
 ### TaskController
 
-Handles spawning tasks with a default timeout, which can also be cancelled by
-calling `cancel` on the task controller. If a `std::time::Duration` is supplied during
-construction of the TaskController, then any tasks spawned by the TaskController will
-automatically be cancelled after the supplied duration has elapsed.
+Handles spawning tasks which can also be cancelled by calling `cancel` on the
+task controller. If a `std::time::Duration` is supplied using the `with_timeout`
+constructor, then any tasks spawned by the TaskController will automatically be
+cancelled after the supplied duration has elapsed.
 
-This provides a different API from Context for the same end result. It's nicer to use when you
-don't need child futures to gracefully shutdown. In cases that you do require graceful shutdown
-of child futures, you will need to pass a Context down, and incorporate the context into normal
-program flow for the child function so that they can react to it as needed and perform custom
-asynchronous cleanup logic.
+This provides a different API from Context for the same end result. It's nicer
+to use when you don't need child futures to gracefully shutdown. In cases that
+you do require graceful shutdown of child futures, you will need to pass a
+Context down, and incorporate the context into normal program flow for the child
+function so that they can react to it as needed and perform custom asynchronous
+cleanup logic.
 
 ## Examples
 
@@ -181,7 +182,7 @@ async fn task_that_takes_too_long() {
 
 #[tokio::main]
 async fn main() {
-    let mut controller = TaskController::new(None);
+    let mut controller = TaskController::new();
 
     let mut join_handles = vec![];
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ async fn main() {
 ```
 
 While this may look no different than simply using tokio::time::timeout, we have retained a
-handle that we can use to explicitely cancel the context, and any additionally spawned
+handle that we can use to explicitly cancel the context, and any additionally spawned
 contexts.
 
 

--- a/README.md
+++ b/README.md
@@ -10,18 +10,19 @@ related futures, with a fallback timeout mechanism. This is accomplished either 
 
 ### Context
 
-Provides Golang like `Context` functionality. A Context in this respect is an object that is passed
-around, primarily to async functions, that is used to determine if long running asynchronous
-tasks should continue to run, or terminate.
+Provides Golang like Context functionality. A Context in this respect is an object that is
+passed around, primarily to async functions, that is used to determine if long running
+asynchronous tasks should continue to run, or terminate.
 
-You build a new Context by calling its `new()` constructor, which optionally takes a duration
-that the context should run for. Calling the `new()` constructor returns the new `Context`
-along with a `Handle`. The `Handle` can either have its `cancel()` method called,
-or it can simply be dropped to cancel the context.
+You build a new Context by calling its `Context::new` constructor, which optionally takes a
+duration that the context should run for. Calling the `Context::new` constructor returns the
+new `Context` along with a `Handle`. The `Handle` can either have its `cancel` method
+called, or it can simply be dropped to cancel the context.
 
 Please note that dropping the `Handle` **will** cancel the context.
 
-If the duration supplied during Context construction elapses, then the Context will also be cancelled.
+If the duration supplied during `Context` construction elapses, then the `Context` will
+also be cancelled.
 
 ## Examples
 
@@ -49,7 +50,7 @@ async fn main() {
 
 ```
 
-While this may look no different than simply using tokio::time::timeout, we have retained a
+While this may look no different than simply using `tokio::time::timeout`, we have retained a
 handle that we can use to explicitly cancel the context, and any additionally spawned
 contexts.
 
@@ -90,24 +91,79 @@ async fn main() {
 
 ```
 
-This pattern is useful if your child future needs to know about the cancel signal. This is
-highly useful in many situations where a child future needs to perform graceful termination.
+Contexts may also be chained by using the `with_parent` constructor in conjunction with
+RefContexts. Chaining a context means that the context will be cancelled if a parent context is
+cancelled. A `RefContext` is simple a wrapper type around an `Arc<Mutex<Context>>` with an
+identical API to `Context`. Here are a few examples to demonstrate how chainable contexts work:
+
+```rust
+use std::time::Duration;
+use tokio::time;
+use tokio::task;
+use tokio_context::context::RefContext;
+
+#[tokio::test]
+async fn cancelling_parent_ctx_cancels_child() {
+    // Note that we can't simply drop the handle here or the context will be cancelled.
+    let (parent_ctx, parent_handle) = RefContext::new(None);
+    let (mut ctx, _handle) = Context::with_parent(&parent_ctx, None);
+
+    parent_handle.cancel();
+
+    // Cancelling a parent will cancel the child context.
+    tokio::select! {
+        _ = ctx.done() => assert!(true),
+        _ = tokio::time::sleep(Duration::from_millis(15)) => assert!(false),
+    }
+}
+
+#[tokio::test]
+async fn cancelling_child_ctx_doesnt_cancel_parent() {
+    // Note that we can't simply drop the handle here or the context will be cancelled.
+    let (mut parent_ctx, _parent_handle) = RefContext::new(None);
+    let (_ctx, handle) = Context::with_parent(&parent_ctx, None);
+
+    handle.cancel();
+
+    // Cancelling a child will not cancel the parent context.
+    tokio::select! {
+        _ = parent_ctx.done() => assert!(false),
+        _ = async {} => assert!(true),
+    }
+}
+
+#[tokio::test]
+async fn parent_timeout_cancels_child() {
+    // Note that we can't simply drop the handle here or the context will be cancelled.
+    let (parent_ctx, _parent_handle) = RefContext::new(Some(Duration::from_millis(5)));
+    let (mut ctx, _handle) =
+        Context::with_parent(&parent_ctx, Some(Duration::from_millis(10)));
+
+    tokio::select! {
+        _ = ctx.done() => assert!(true),
+        _ = tokio::time::sleep(Duration::from_millis(7)) => assert!(false),
+    }
+}
+```
+
+The Context pattern is useful if your child future needs to know about the cancel signal. This
+is highly useful in many situations where a child future needs to perform graceful termination.
 
 In instances where graceful termination of child futures is not needed, the API provided by
-`tokio_context::task::TaskController` is much nicer to use. It doesn't pollute children with an
-extra function argument of the context. It will however perform abrupt future termination,
-which may not always be desired.
+`TaskController` is much nicer to use. It doesn't pollute children with an extra
+function argument of the context. It will however perform abrupt future
+termination, which may not always be desired.
 
 ### TaskController
 
 Handles spawning tasks with a default timeout, which can also be cancelled by
-calling cancel() on the task controller. If a Duration is supplied during construction of the
-TaskController, then any tasks spawned by the TaskController will automatically be cancelled
-after the supplied duration has elapsed.
+calling `cancel` on the task controller. If a `std::time::Duration` is supplied during
+construction of the TaskController, then any tasks spawned by the TaskController will
+automatically be cancelled after the supplied duration has elapsed.
 
 This provides a different API from Context for the same end result. It's nicer to use when you
 don't need child futures to gracefully shutdown. In cases that you do require graceful shutdown
-of child futures, you will need to pass a Context down, and encorporate the context into normal
+of child futures, you will need to pass a Context down, and incorporate the context into normal
 program flow for the child function so that they can react to it as needed and perform custom
 asynchronous cleanup logic.
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -46,7 +46,7 @@
 /// ```
 ///
 /// While this may look no different than simply using tokio::time::timeout, we have retained a
-/// handle that we can use to explicitely cancel the context, and any additionally spawned
+/// handle that we can use to explicitly cancel the context, and any additionally spawned
 /// contexts.
 ///
 ///
@@ -151,7 +151,7 @@ pub struct Context {
 }
 
 /// A handle returned from constructing a new `Context`. Used to cancel the context. You can
-/// explicitely call `cancel()`, or, you can simply drop the Handle to cancel the context.
+/// explicitly call `cancel()`, or, you can simply drop the Handle to cancel the context.
 ///
 /// It's also used to spawn new contexts. This fits cleaner into Rusts ownership system. We can
 /// only create new receivers by asking for them from the underlying Sender. This also ensures that
@@ -185,7 +185,7 @@ impl Handle {
 
 impl Context {
     /// Builds a new Context. The done() method returns a future that will complete when
-    /// either the cancel signal is cancelled, or when the optional timeout has elapsed.
+    /// either the handle is cancelled, or when the optional timeout has elapsed.
     pub fn new(timeout: Option<Duration>) -> (Context, Handle) {
         let timeout = if let Some(t) = timeout {
             Some(Instant::now() + t)
@@ -201,7 +201,7 @@ impl Context {
     }
 
     /// Blocks until either the provided timeout elapses, or a cancel signal is received from
-    /// calling cancel() on the CancelHandle that was returned during initial construction.
+    /// calling cancel() on the Handle that was returned during initial construction.
     #[allow(unused_must_use)] // We expect a receive error that the channel was closed.
     pub async fn done(&mut self) {
         if let Some(instant) = self.timeout {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,22 +2,24 @@
 //!
 //! Provides two different methods for cancelling futures with a provided handle for cancelling all
 //! related futures, with a fallback timeout mechanism. This is accomplished either with the
-//! `Context` API, or with the `TaskController` API depending on a users needs.
+//! [`Context`] API, or with the [`TaskController`] API depending on a users needs.
 //!
 //! ## Context
 //!
-//! Provides Golang like `Context` functionality. A Context in this respect is an object that is passed
-//! around, primarily to async functions, that is used to determine if long running asynchronous
-//! tasks should continue to run, or terminate.
+//! Provides Golang like Context functionality. A Context in this respect is an object that is
+//! passed around, primarily to async functions, that is used to determine if long running
+//! asynchronous tasks should continue to run, or terminate.
 //!
-//! You build a new Context by calling its `new()` constructor, which optionally takes a duration
-//! that the context should run for. Calling the `new()` constructor returns the new `Context`
-//! along with a `Handle`. The `Handle` can either have its `cancel()` method called,
-//! or it can simply be dropped to cancel the context.
+//! You build a new Context by calling its [`new`](fn@context::Context::new)
+//! constructor, which optionally takes a duration that the context should run for. Calling the
+//! [`new`](fn@context::Context::new) constructor returns the new [`Context`] along
+//! with a [`Handle`]. The [`Handle`] can either have its `cancel` method called, or it can simply
+//! be dropped to cancel the context.
 //!
-//! Please note that dropping the `Handle` **will** cancel the context.
+//! Please note that dropping the [`Handle`] **will** cancel the context.
 //!
-//! If the duration supplied during Context construction elapses, then the Context will also be cancelled.
+//! If the duration supplied during [`Context`] construction elapses, then the [`Context`] will
+//! also be cancelled.
 //!
 //! # Examples
 //!
@@ -45,7 +47,7 @@
 //!
 //! ```
 //!
-//! While this may look no different than simply using tokio::time::timeout, we have retained a
+//! While this may look no different than simply using [`tokio::time::timeout`], we have retained a
 //! handle that we can use to explicitly cancel the context, and any additionally spawned
 //! contexts.
 //!
@@ -86,24 +88,79 @@
 //!
 //! ```
 //!
-//! This pattern is useful if your child future needs to know about the cancel signal. This is
-//! highly useful in many situations where a child future needs to perform graceful termination.
+//! Contexts may also be chained by using the `with_parent` constructor in conjunction with
+//! RefContexts. Chaining a context means that the context will be cancelled if a parent context is
+//! cancelled. A [`RefContext`] is simple a wrapper type around an `Arc<Mutex<Context>>` with an
+//! identical API to [`Context`]. Here are a few examples to demonstrate how chainable contexts work:
+//!
+//! ```rust
+//! use std::time::Duration;
+//! use tokio::time;
+//! use tokio::task;
+//! use tokio_context::context::RefContext;
+//!
+//! #[tokio::test]
+//! async fn cancelling_parent_ctx_cancels_child() {
+//!     // Note that we can't simply drop the handle here or the context will be cancelled.
+//!     let (parent_ctx, parent_handle) = RefContext::new(None);
+//!     let (mut ctx, _handle) = Context::with_parent(&parent_ctx, None);
+//!
+//!     parent_handle.cancel();
+//!
+//!     // Cancelling a parent will cancel the child context.
+//!     tokio::select! {
+//!         _ = ctx.done() => assert!(true),
+//!         _ = tokio::time::sleep(Duration::from_millis(15)) => assert!(false),
+//!     }
+//! }
+//!
+//! #[tokio::test]
+//! async fn cancelling_child_ctx_doesnt_cancel_parent() {
+//!     // Note that we can't simply drop the handle here or the context will be cancelled.
+//!     let (mut parent_ctx, _parent_handle) = RefContext::new(None);
+//!     let (_ctx, handle) = Context::with_parent(&parent_ctx, None);
+//!
+//!     handle.cancel();
+//!
+//!     // Cancelling a child will not cancel the parent context.
+//!     tokio::select! {
+//!         _ = parent_ctx.done() => assert!(false),
+//!         _ = async {} => assert!(true),
+//!     }
+//! }
+//!
+//! #[tokio::test]
+//! async fn parent_timeout_cancels_child() {
+//!     // Note that we can't simply drop the handle here or the context will be cancelled.
+//!     let (parent_ctx, _parent_handle) = RefContext::new(Some(Duration::from_millis(5)));
+//!     let (mut ctx, _handle) =
+//!         Context::with_parent(&parent_ctx, Some(Duration::from_millis(10)));
+//!
+//!     tokio::select! {
+//!         _ = ctx.done() => assert!(true),
+//!         _ = tokio::time::sleep(Duration::from_millis(7)) => assert!(false),
+//!     }
+//! }
+//! ```
+//!
+//! The Context pattern is useful if your child future needs to know about the cancel signal. This
+//! is highly useful in many situations where a child future needs to perform graceful termination.
 //!
 //! In instances where graceful termination of child futures is not needed, the API provided by
-//! `tokio_context::task::TaskController` is much nicer to use. It doesn't pollute children with an
-//! extra function argument of the context. It will however perform abrupt future termination,
+//! [`TaskController`] is much nicer to use. It doesn't pollute children with
+//! an extra function argument of the context. It will however perform abrupt future termination,
 //! which may not always be desired.
 //!
 //! ## TaskController
 //!
 //! Handles spawning tasks with a default timeout, which can also be cancelled by
-//! calling cancel() on the task controller. If a Duration is supplied during construction of the
-//! TaskController, then any tasks spawned by the TaskController will automatically be cancelled
-//! after the supplied duration has elapsed.
+//! calling `cancel` on the task controller. If a [`Duration`] is supplied during
+//! construction of the TaskController, then any tasks spawned by the TaskController will
+//! automatically be cancelled after the supplied duration has elapsed.
 //!
 //! This provides a different API from Context for the same end result. It's nicer to use when you
 //! don't need child futures to gracefully shutdown. In cases that you do require graceful shutdown
-//! of child futures, you will need to pass a Context down, and encorporate the context into normal
+//! of child futures, you will need to pass a Context down, and incorporate the context into normal
 //! program flow for the child function so that they can react to it as needed and perform custom
 //! asynchronous cleanup logic.
 //!
@@ -139,6 +196,12 @@
 //!     }
 //! }
 //! ```
+//!
+//! [`Context`]: context::Context
+//! [`Handle`]: context::Handle
+//! [`RefContext`]: context::RefContext
+//! [`TaskController`]: task::TaskController
+//! [`Duration`]: std::time::Duration
 
 /// Contains the Context API, providing a form of a cancellation token to child processes, with the
 /// option of falling back to a timeout cancel.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@
 //! ```
 //!
 //! While this may look no different than simply using tokio::time::timeout, we have retained a
-//! handle that we can use to explicitely cancel the context, and any additionally spawned
+//! handle that we can use to explicitly cancel the context, and any additionally spawned
 //! contexts.
 //!
 //!

--- a/src/task.rs
+++ b/src/task.rs
@@ -3,9 +3,9 @@ use tokio::sync::broadcast::Sender;
 use tokio::{sync::broadcast, time::Instant};
 
 /// Handles spawning tasks with a default timeout, which can also be cancelled by
-/// calling cancel() on the task controller. If a Duration is supplied during construction of the
-/// TaskController, then any tasks spawned by the TaskController will automatically be cancelled
-/// after the supplied duration has elapsed.
+/// calling `cancel` on the task controller. If a [`std::time::Duration`] is supplied during
+/// construction of the TaskController, then any tasks spawned by the TaskController will
+/// automatically be cancelled after the supplied duration has elapsed.
 ///
 /// This provides a different API from Context for the same end result. It's nicer to use when you
 /// don't need child futures to gracefully shutdown. In cases that you do require graceful shutdown


### PR DESCRIPTION
This provides a means by which we can chain contexts together, such that
cancelling a parent context will cancel a child context, but not visa
versa. May be chained as many times as you wish.

This PR also simplifies the API for both Context and TaskController. 
Now there are separate constructors to construct without vs with a timeout. 
This allows for simpler construction at call sites.